### PR TITLE
Add info on Messages page

### DIFF
--- a/pages/features/notifications/index.vue
+++ b/pages/features/notifications/index.vue
@@ -60,7 +60,7 @@ export default {
         {
           name: 'Callout',
           props: {
-            callout: 'Automatic appointment notifications lessen client no-shows. Include relevant info about their appointment and send payment reminders afterwards.'
+            callout: 'Automatic appointment notifications lessen client no-shows. Include relevant info about their appointment and send payment information afterwards.'
           }
         },
         {
@@ -93,6 +93,11 @@ export default {
               icon: 'send',
               title: 'Invoice and payment reminder notifications',
               description: 'Send invoices to your clients (and yourself) by SMS and email. Quickly remind your clients about an outstanding invoice by resending it as many times as you like.'
+              }
+            {
+              icon: 'sms_failed',
+              title: 'View the status of your sent notifications',
+              description: 'Check whether an SMS and/or email notification has been sent, delivered, received or failed.'
               }
             ]
           }

--- a/pages/features/notifications/index.vue
+++ b/pages/features/notifications/index.vue
@@ -93,12 +93,12 @@ export default {
               icon: 'send',
               title: 'Invoice and payment reminder notifications',
               description: 'Send invoices to your clients (and yourself) by SMS and email. Quickly remind your clients about an outstanding invoice by resending it as many times as you like.'
-              }
+            },
             {
               icon: 'sms_failed',
               title: 'View the status of your sent notifications',
               description: 'Check whether an SMS and/or email notification has been sent, delivered, received or failed.'
-              }
+             }
             ]
           }
         },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -100,7 +100,7 @@ export default {
             isLeft: true,
             withBackground: true,
             tagline: 'Lessen no-shows with notifications',
-            content: 'Automatically send customisable SMS or email notifications to confirm, remind, reschedule and cancel appointments through your online appointment system',
+            content: 'Automatically send customisable SMS or email notifications to confirm, remind, reschedule and cancel appointments through your online appointment system.',
             img: 'img/notification.png'
           }
         },


### PR DESCRIPTION
* Add a missing fullstop to the home page. Nice.
* Add info on the new Messages page to https://appointmentguru.co/features/notifications.